### PR TITLE
Fix compiler warnings

### DIFF
--- a/priv/repo/migrations/20170205181507_add-retros-table.exs
+++ b/priv/repo/migrations/20170205181507_add-retros-table.exs
@@ -5,7 +5,7 @@ defmodule :"Elixir.RemoteRetro.Repo.Migrations.Add-retros-table" do
     create table(:retros, primary_key: false) do
       add :id, :uuid, primary_key: true
 
-      timestamps
+      timestamps()
     end
   end
 end

--- a/web/controllers/auth_controller.ex
+++ b/web/controllers/auth_controller.ex
@@ -3,7 +3,7 @@ defmodule RemoteRetro.AuthController do
   alias RemoteRetro.Google
 
   def index(conn, _params) do
-    redirect conn, external: authorize_url!
+    redirect conn, external: authorize_url!()
   end
 
   def callback(conn, %{"code" => code}) do

--- a/web/oauth/google.ex
+++ b/web/oauth/google.ex
@@ -4,7 +4,7 @@ defmodule RemoteRetro.Google do
   @oauth_client Application.get_env(:remote_retro, :oauth_client)
 
   def authorize_url!(params) do
-    @oauth_client.authorize_url!(client, params)
+    @oauth_client.authorize_url!(client(), params)
   end
 
   def get_user_info!(code) do
@@ -16,8 +16,8 @@ defmodule RemoteRetro.Google do
   end
 
   defp retrieve_token!(code) do
-    client
-    |> @oauth_client.put_param(:client_secret, client.client_secret)
+    client()
+    |> @oauth_client.put_param(:client_secret, client().client_secret)
     |> @oauth_client.get_token!(code: code)
   end
 


### PR DESCRIPTION
Running migrations throws a few errors about naked variables.  This PR cleans those up.